### PR TITLE
Make `Client` instance available to instrumentation.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,7 @@ const debug = require('debug')('agentops:client');
  * ```
  */
 export class Client {
-  private config: Config;
+  public config: Config;
   public readonly registry: InstrumentationRegistry;
   private core: TracingCore | null = null;
   private api: API | null = null;
@@ -43,7 +43,7 @@ export class Client {
       apiKey: process.env.AGENTOPS_API_KEY,
       logLevel: (process.env.AGENTOPS_LOG_LEVEL as LogLevel) || 'error'
     };
-    this.registry = new InstrumentationRegistry();
+    this.registry = new InstrumentationRegistry(this);
   }
 
   /**
@@ -87,7 +87,7 @@ export class Client {
     this.core = new TracingCore(
       this.config,
       await this.getAuthToken(),
-      this.registry.getActiveInstrumentors(this.config.serviceName!),
+      this.registry.getActiveInstrumentors(),
       resource
     );
     this.setupExitHandlers();

--- a/src/instrumentation/base.ts
+++ b/src/instrumentation/base.ts
@@ -5,6 +5,8 @@ import {
   InstrumentationConfig
 } from '@opentelemetry/instrumentation';
 import { InstrumentorMetadata } from '../types';
+import { Client } from '../client';
+import { getPackageVersion } from '../attributes';
 
 const debug = require('debug')('agentops:instrumentation:base');
 
@@ -65,6 +67,14 @@ export abstract class InstrumentationBase extends _InstrumentationBase {
   static readonly metadata: InstrumentorMetadata;
   static readonly useRuntimeTargeting?: boolean = false;
   private isRuntimeSetup: boolean = false;
+  private client: Client;
+
+  constructor(
+    client: Client
+  ) {
+    super(client.config.serviceName!, getPackageVersion(), {});
+    this.client = client;
+  }
 
   /**
    * Initializes the instrumentation module definition using the static metadata.

--- a/src/instrumentation/registry.ts
+++ b/src/instrumentation/registry.ts
@@ -49,7 +49,7 @@ export class InstrumentationRegistry {
           }
         }
       }
-    }``
+    }
   }
 
   /**


### PR DESCRIPTION
Dependency inject our client instance into instrumentation. 

Previously, we were passing the `serviceName` and `serviceVersion` up as arguments, so this makes it easier to get it straight from the Config when we need it. 

Also useful to have the client available in the instrumentors for things like log export where we need to connect to the API. 